### PR TITLE
(Maint) Update releases and snapshots repositories

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,8 +23,8 @@
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}
 
-  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                 ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
+  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
+                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
The old repositories URLS were incorrect, which caused an error message when trying to start a REPL. The REPL now starts successfully.