### PR TITLE
(SERVER-2215) Update cljs tools and use figwheel-sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To run:
 * run `(go)`
 * run `(start-figwheel)`
 * open a browser to localhost:8080
+    * For the figwheel server, the host should be localhost:3449/metrics.html
 
 ```
 $ lein repl
@@ -38,7 +39,7 @@ Commands:
 => (start-figwheel) ;; starts figwheel, to dynamically
                     ;;  recompile cljs code and send it to
                     ;;  the browser
-=> (browser-repl)   ;; starts cljs repl, may need to reload
+=> (cljs-repl)   ;; starts cljs repl, may need to reload
                     ;;  browser to attach
 user=> (go)
 ...

--- a/dev/clj/puppetlabs/metrics/dashboard/demo/handler.clj
+++ b/dev/clj/puppetlabs/metrics/dashboard/demo/handler.clj
@@ -58,7 +58,9 @@
           (update-timer-metrics requests-atom)
           (update-timer-metrics functions-atom)
           {:status 200
-           :headers {"Content-Type" "application/json"}
+           :headers {"Content-Type" "application/json"
+                     "Access-Control-Allow-Origin" "http://localhost:3449"
+                     "Access-Control-Allow-Credentials" "true"}
            :body (json/generate-string
                    {:metrics-boxes (random-metrics-box-data ["metric1" "metric2" "metric3" "metric4" "metric5"])
                     :requests (vals @requests-atom)

--- a/dev/clj/user.clj
+++ b/dev/clj/user.clj
@@ -4,7 +4,7 @@
             [puppetlabs.trapperkeeper.app :as tka]
             [puppetlabs.metrics.dashboard.demo.service :refer [metrics-service]]
             [clojure.tools.namespace.repl :refer [refresh]]
-            [leiningen.core.main :as lein]))
+            [figwheel-sidecar.repl-api :as ra]))
 
 (defn user-config
   []
@@ -24,6 +24,7 @@ Commands:
 => (start-figwheel) ;; starts figwheel, to dynamically
                     ;;  recompile cljs code and send it to
                     ;;  the browser
+=> (cljs-repl)      ;; starts a clojurescript repl
 "))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -58,8 +59,11 @@ Commands:
 ;;; CLJS utils
 
 (defn start-figwheel []
-  (future
     (print "Starting figwheel.\n")
-    (lein/-main ["figwheel"])))
+    (ra/start-figwheel!))
+
+(defn cljs-repl []
+  (start-figwheel)
+  (ra/cljs-repl))
 
 (help)

--- a/dev/cljs/puppetlabs/metrics/dashboard/demo/core.cljs
+++ b/dev/cljs/puppetlabs/metrics/dashboard/demo/core.cljs
@@ -71,10 +71,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn server-random-data-fn
-  [requests-atom functions-atom]
+  [requests-atom functions-atom server-port]
   (fn [channel]
     (go
-      (let [response (async/<! (http/get "/random-data"))]
+      (let [response (async/<! (http/get server-port))]
         (if-not (= 200 (:status response))
           (do
             ;; TODO: better error handling
@@ -147,7 +147,7 @@
                        ;(local-random-data-fn requests-atom functions-atom)
 
                        ;;; or, uncomment this line to get random data from the server
-                       (server-random-data-fn requests-atom functions-atom)
+                       (server-random-data-fn requests-atom functions-atom "http://localhost:8080/random-data")
                        )]
     (reagent/render-component [(metrics-boxes
                                  #(metrics-utils/get-values-for-metric metrics-data %))]

--- a/project.clj
+++ b/project.clj
@@ -6,17 +6,20 @@
 
   :source-paths ["src/cljs"]
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "2.0.1"]
+                   :inherit [:managed-dependencies]}
+
+  :dependencies [[org.clojure/clojure "1.9.0"]
 
                  ;; transitive dependencies
-                 [org.clojure/clojurescript "1.7.228"]
+                 [org.clojure/clojurescript "1.10.238"]
                  ;; end transitive dependencies
-
-                 [cljsjs/d3 "3.5.7-1"]
+                 [com.fasterxml.jackson.core/jackson-core]
+                 [cljsjs/d3 "4.12.0-0"]
                  [cljsjs/react "0.13.3-1"]
                  [reagent "0.5.1"]
                  [com.andrewmcveigh/cljs-time "0.4.0"]
-                 [org.clojure/core.async "0.2.374"]]
+                 [org.clojure/core.async]]
 
   :pedantic? :abort
 
@@ -31,7 +34,8 @@
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :plugins [[lein-cljsbuild "1.1.2" :exclusions [org.clojure/clojure]]]
+  :plugins [[lein-cljsbuild "1.1.2" :exclusions [org.clojure/clojure]]
+            [lein-parent "0.3.1"]]
 
   :min-lein-version "2.5.0"
 
@@ -49,31 +53,36 @@
                        :dependencies [
                                       ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
                                       ;; transitive dependencies
-                                      [org.clojure/tools.macro "0.1.5"]
-                                      [org.clojure/tools.cli "0.3.1"]
-                                      [prismatic/schema "0.4.3"]
-                                      [prismatic/plumbing "0.4.3"]
-                                      [clj-time "0.7.0"]
+                                      [org.clojure/tools.macro]
+                                      [org.clojure/tools.cli]
+                                      [prismatic/schema]
+                                      [prismatic/plumbing]
+                                      [clj-time]
 
                                       [org.codehaus.plexus/plexus-utils "3.0.15"]
-                                      [org.apache.maven.wagon/wagon-provider-api "2.7"]
-                                      [org.apache.httpcomponents/httpclient "4.3.5"]
-                                      [commons-codec "1.10"]
+                                      [org.apache.maven.wagon/wagon-provider-api]
+                                      [org.apache.httpcomponents/httpclient]
+                                      [commons-codec]
 
-                                      [puppetlabs/kitchensink "1.2.0"]
+                                      [org.clojure/tools.analyzer "0.6.9"]
+                                      [org.clojure/tools.analyzer.jvm "0.7.0"]
+                                      [puppetlabs/kitchensink]
+                                      [com.cemerick/piggieback "0.2.1"]
                                       ;; end transitive dependencies
                                       ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-                                      [puppetlabs/trapperkeeper "1.1.0"]
-                                      [puppetlabs/trapperkeeper-webserver-jetty9 "1.3.0"]
-                                      [puppetlabs/comidi "0.2.1"]
+                                      [puppetlabs/trapperkeeper]
+                                      [puppetlabs/trapperkeeper-webserver-jetty9]
+                                      [puppetlabs/comidi]
+                                      [org.clojure/tools.nrepl "0.2.13"]
+                                      [org.clojure/tools.namespace]
 
-                                      [org.clojure/tools.namespace "0.2.10"]
-                                      [leiningen "2.5.1"]
-                                      [cljs-http "0.1.39"]]
+                                      [cljs-http "0.1.39"]
+                                      [figwheel-sidecar "0.5.4-6" :exclusions [org.clojure/clojure]]]
 
-                       :plugins      [[lein-figwheel "0.5.0-6" :exclusions [org.clojure/clojurescript
-                                                                            org.codehaus.plexus/plexus-utils]]]
+                       :plugins      [[lein-figwheel "0.5.0-6" :exclusions [commons-codec
+                                                                            org.clojure/clojure
+                                                                            commons-io]]]
 
                        :figwheel     {:http-server-root "puppetlabs/metrics/dashboard/public"
                                       :server-port      3449
@@ -89,4 +98,5 @@
              :uberjar {:cljsbuild {:jar    true
                                    :builds {:app
                                             {:compiler
-                                                           {:main "puppetlabs.metrics.dashboard.demo.prod"}}}}}})
+                                                           {:main "puppetlabs.metrics.dashboard.demo.prod"}}}}}}
+  :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]})

--- a/src/cljs/puppetlabs/metrics/dashboard/metrics_box.cljs
+++ b/src/cljs/puppetlabs/metrics/dashboard/metrics_box.cljs
@@ -51,24 +51,18 @@
 
 (defn initialize-counterbox
   [x-axis-domain data-fn counterbox-selection]
-  (let [x   (.. js/d3.time
-                scale
-                (domain x-axis-domain)
-                (range (array 0 w)))
-        y   (.. js/d3.scale
-                linear
-                (range (array h 1)))
-        line (.. js/d3.svg
-                 area
-                 (interpolate "linear")
-                 (x #(+ 1 (x (.-time %))))
-                 (y1 (+ h 1))
-                 (y0 #(y (.-value %))))
-        axis  (.. js/d3.svg
-                  axis
-                  (scale y)
-                  (orient "left")
-                  (ticks 3))
+  (let [x   (-> js/d3 (.scaleTime)
+                (.domain x-axis-domain)
+                (.range (array 0 w)))
+        y   (-> js/d3 (.scaleLinear)
+                (.range (array h 1)))
+        line (-> js/d3 (.area)
+                 (.x #(+ 1 (x (.-time %))))
+                 (.y1 (+ h 1))
+                 (.y0 #(y (.-value %))))
+        axis  (-> js/d3 (.axisLeft)
+                  (.scale y)
+                  (.ticks 3))
         svg-line-g (.select counterbox-selection ".line_g")
         svg-line-path (.select counterbox-selection ".line")]
     (.attr svg-line-g "clip-path" "url(#clip)")
@@ -135,15 +129,15 @@
                                         now
                                         (* (- num-historical-data-points 1)
                                            polling-interval))))]
-      (.. box-node
-          (select ".line")
-          (attr "d" (line data))
-          (attr "transform" nil)
-          transition
-          (duration polling-interval)
-          (ease "linear")
-          (attr "transform" translate)
-          (each "end" (fn [] (redraw-box!
+      (-> box-node
+          (.select ".line")
+          (.attr "d" (line data))
+          (.attr "transform" nil)
+          .transition
+          (.duration polling-interval)
+          (.ease js/d3.easeLinear)
+          (.attr "transform" translate)
+          (.on "end" (fn [] (redraw-box!
                                num-historical-data-points
                                polling-interval
                                box


### PR DESCRIPTION
cljs-dashboard-widgets used older clojure, clojurescript, and cljsjs/d3 dependencies. I updated these to modern versions and added clj-parent to manage the rest of the dependencies in the project. Upgrading to d3 v4 broke some of the metrix-box animation, so I fixed that as well. Figwheel required a lein dependency to run lein figwheel, but upgrading to figwheel-sidecar allowed me to remove that dependency.